### PR TITLE
Add new tool: oca-repo-add-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Go to the conf repo on your file system and run this:
 
 Review, stage all the changes, commit and open a PR.
 
+You can prevent this tool to edit a repo by adding ``manual_branch_mgmt`` boolean flag to repo's conf.
+
 ## Licenses
 
 This repository is licensed under [AGPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Features:
 * create/update repositories
 * create/update teams and roles
 * create/update branches
+* add new branches to existing YAML conf
+
+
+## Available tools
+
+* ``oca-repo-manage`` used to automatically maintain repositories based on YAML conf (see OCA conf below)
+* ``oca-repo-pages`` used to automatically generate repo inventory docs from the same YAML conf
+* ``oca-repo-add-branch`` used to manually add new branches to existing conf
 
 ## I can use it on my own organization?
 
@@ -28,6 +36,36 @@ https://github.com/OCA/repo-maintainer-conf
 ## Bootstrap
 
 You can use the script `scripts/bootstrap_data.py` to generate the conf out of existing repos. Run it with `--help` to see the options.
+
+# Usage
+
+## Manage repos
+
+This action is normally performed via GH actions in the conf repo. You should not run it manually.
+
+Yet, here's the command:
+
+
+    oca-repo-manage --org $GITHUB_REPOSITORY_OWNER --token ${{secrets.GIT_PUSH_TOKEN}} --conf-dir ./conf
+
+## Generate docs
+
+This action is normally performed via GH actions in the conf repo. You should not run it manually.
+
+Yet, here's the command:
+
+    oca-repo-pages --org $GITHUB_REPOSITORY_OWNER --conf-dir conf --path docsource
+
+## Add new branches to all repos
+
+This action has to be performed manually when you need a new branch to be added to all repos in your conf.
+Eg: when a new Odoo version is released.
+
+Go to the conf repo on your file system and run this:
+
+    oca-repo-add-branch --conf-dir ./conf/ --branch 18.0
+
+Review, stage all the changes, commit and open a PR.
 
 ## Licenses
 

--- a/oca_repo_maintainer/cli/manage.py
+++ b/oca_repo_maintainer/cli/manage.py
@@ -15,7 +15,6 @@ from ..tools.manager import RepoManager
     "--token", required=True, prompt="Your github token", envvar="GITHUB_TOKEN"
 )
 @click.option(
-    # FIXME: switch to OCA when ready
     "--org",
     default="OCA",
     prompt="Your organization",

--- a/oca_repo_maintainer/cli/manage.py
+++ b/oca_repo_maintainer/cli/manage.py
@@ -6,6 +6,7 @@
 
 import click
 
+from ..tools.conf_file_manager import ConfFileManager
 from ..tools.manager import RepoManager
 
 
@@ -21,7 +22,17 @@ from ..tools.manager import RepoManager
     help="The organizattion.",
 )
 def manage(conf_dir, org, token):
+    """Setup and update repositories and teams."""
     RepoManager(conf_dir, org, token).run()
+
+
+@click.command()
+@click.option("--conf-dir", required=True, help="Folder where configuration is stored")
+@click.option("--branch", required=True, help="New branch name to add")
+@click.option("--default", default=True, help="Set default branch as default.")
+def add_branch(conf_dir, branch, default=True):
+    """Add a branch to all repositories in the configuration."""
+    ConfFileManager(conf_dir).add_branch(branch, default=default)
 
 
 if __name__ == "__main__":

--- a/oca_repo_maintainer/cli/pages.py
+++ b/oca_repo_maintainer/cli/pages.py
@@ -13,7 +13,6 @@ from ..tools.gh_pages import GHPageGenerator
 @click.option("--conf-dir", required=True, help="Folder where configuration is stored")
 @click.option("--path", required=True, help="Folder where pages must be generated")
 @click.option(
-    # FIXME: switch to OCA when ready
     "--org",
     default="OCA",
     prompt="Your organization",

--- a/oca_repo_maintainer/tools/conf_file_manager.py
+++ b/oca_repo_maintainer/tools/conf_file_manager.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Camptocamp SA
+# @author: Simone Orsi
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+import sys
+
+from .utils import ConfLoader
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+_logger = logging.getLogger(__name__)
+
+
+class ConfFileManager:
+    """Update existing configuration files."""
+
+    def __init__(self, conf_dir):
+        self.conf_dir = conf_dir
+        self.conf_loader = ConfLoader(self.conf_dir)
+        self.conf_repo = self.conf_loader.load_conf(
+            "repo", checksum=False, by_filepath=True
+        )
+
+    def add_branch(self, branch, default=True):
+        """Add a branch to all repositories in the configuration."""
+        for filepath, repo in self.conf_repo.items():
+            for repo_data in repo.values():
+                if branch not in repo_data["branches"]:
+                    repo_data["branches"].append(branch)
+                if default:
+                    repo_data["default_branch"] = branch
+            self.conf_loader.save_conf(filepath, repo)
+            _logger.info("Branch %s added to %s.", branch, filepath.as_posix())

--- a/oca_repo_maintainer/tools/conf_file_manager.py
+++ b/oca_repo_maintainer/tools/conf_file_manager.py
@@ -30,12 +30,21 @@ class ConfFileManager:
         """Add a branch to all repositories in the configuration."""
         for filepath, repo in self.conf_repo.items():
             for repo_data in repo.values():
+                if self._has_manual_branch_mgmt(repo_data):
+                    _logger.info(
+                        "Skipping repo %s as manual_branch_mgmt is enabled.",
+                        filepath.as_posix(),
+                    )
+                    continue
                 if self._can_add_new_branch(branch, repo_data):
                     repo_data["branches"].append(branch)
                 if default and self._can_change_default_branch(repo_data):
                     repo_data["default_branch"] = branch
             self.conf_loader.save_conf(filepath, repo)
             _logger.info("Branch %s added to %s.", branch, filepath.as_posix())
+
+    def _has_manual_branch_mgmt(self, repo_data):
+        return repo_data.get("manual_branch_mgmt")
 
     frozen_branches = ("master", "main")
 

--- a/oca_repo_maintainer/tools/conf_file_manager.py
+++ b/oca_repo_maintainer/tools/conf_file_manager.py
@@ -37,12 +37,14 @@ class ConfFileManager:
             self.conf_loader.save_conf(filepath, repo)
             _logger.info("Branch %s added to %s.", branch, filepath.as_posix())
 
+    frozen_branches = ("master", "main")
+
     def _can_add_new_branch(self, branch, repo_data):
         branches = repo_data["branches"]
         return (
             branch not in branches
-            and "master" not in branches
-            and repo_data.get("default_branch") != "master"
+            and all(x not in branches for x in self.frozen_branches)
+            and repo_data.get("default_branch") not in self.frozen_branches
         )
 
     def _can_change_default_branch(self, repo_data):
@@ -51,5 +53,5 @@ class ConfFileManager:
             "default_branch" in repo_data
             # If the branch is "master" it means this is likely the repo of a tool
             # and we have only one working branch.
-            and repo_data["default_branch"] != "master"
+            and repo_data["default_branch"] not in self.frozen_branches
         )

--- a/oca_repo_maintainer/tools/utils.py
+++ b/oca_repo_maintainer/tools/utils.py
@@ -29,17 +29,25 @@ class ConfLoader:
     def _load_checksum(self):
         return self.load_conf("checksum", checksum=False)
 
-    def load_conf(self, name, checksum=True):
+    def load_conf(self, name, checksum=True, by_filepath=False):
         conf = {}
         path = self.conf_dir / name
         filepath = path.with_suffix(".yml")
         if filepath.exists():
             # direct yml files
-            conf.update(self._load_conf_from_file(filepath, checksum=checksum))
+            data = self._load_conf_from_file(filepath, checksum=checksum)
+            if by_filepath:
+                conf[filepath] = data
+            else:
+                conf.update(data)
         else:
             # folders containing ymls
             for filepath in path.rglob("*.yml"):
-                conf.update(self._load_conf_from_file(filepath, checksum=checksum))
+                data = self._load_conf_from_file(filepath, checksum=checksum)
+                if by_filepath:
+                    conf[filepath] = data
+                else:
+                    conf.update(data)
         return SmartDict(conf)
 
     def _load_conf_from_file(self, filepath, checksum=True):

--- a/oca_repo_maintainer/tools/utils.py
+++ b/oca_repo_maintainer/tools/utils.py
@@ -50,6 +50,16 @@ class ConfLoader:
                     conf.update(data)
         return SmartDict(conf)
 
+    def save_conf(self, filepath, conf):
+        # TODO Use ruamel.yaml to keep the original format of the file.
+        # Yet, is not critical for now, because the pre-commit conf
+        # on repo-maintainer-conf will take care of it.
+        # However, it would be nice to have it here too.
+        with filepath.open("w") as f:
+            # at least keep the quotes consistent, you silly pyyaml
+            txt = yaml.dump(conf).replace(*"'", *'"')
+            f.write(txt)
+
     def _load_conf_from_file(self, filepath, checksum=True):
         conf = {}
         with filepath.open() as fd:

--- a/scripts/bootstrap_data.py
+++ b/scripts/bootstrap_data.py
@@ -114,7 +114,6 @@ def prepare_repo(gh_org, conf_dir, whitelist=None):
 
 @click.command()
 @click.option(
-    # FIXME: switch to OCA when ready
     "--org",
     default="OCA",
     prompt="Your organization",

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     entry_points={
         "console_scripts": [
             "oca-repo-manage = oca_repo_maintainer.cli.manage:manage",
+            "oca-repo-add-branch = oca_repo_maintainer.cli.manage:add_branch",
             "oca-repo-pages = oca_repo_maintainer.cli.pages:pages",
         ]
     },

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_manager
+from . import test_conf_file_manager

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,7 @@ from vcr import VCR
 
 conf_path = Path(__file__).parent / "conf"
 conf_path2 = Path(__file__).parent / "conf2"
+conf_path_with_tools = Path(__file__).parent / "conf_with_tools"
 cassettes_path = Path(__file__).parent / "cassettes"
 
 

--- a/tests/conf_with_tools/repo/repo_for_addons.yml
+++ b/tests/conf_with_tools/repo/repo_for_addons.yml
@@ -10,3 +10,14 @@ test-repo-for-addons:
   branches:
     - "16.0"
     - "15.0"
+test-repo-for-addons-manual:
+  name: Test repo for addons with manual mgmt flag
+  description: Repo used to run real tests on oca-repo-manage tool.
+  category: Logistics
+  psc: test-team-1
+  maintainers: []
+  default_branch: "16.0"
+  branches:
+    - "16.0"
+    - "15.0"
+  manual_branch_mgmt: true

--- a/tests/conf_with_tools/repo/repo_for_addons.yml
+++ b/tests/conf_with_tools/repo/repo_for_addons.yml
@@ -1,0 +1,12 @@
+# For testing: this repo must exist already
+# but have a different default branch
+test-repo-for-addons:
+  name: Test repo for addons
+  description: Repo used to run real tests on oca-repo-manage tool.
+  category: Logistics
+  psc: test-team-1
+  maintainers: []
+  default_branch: "16.0"
+  branches:
+    - "16.0"
+    - "15.0"

--- a/tests/conf_with_tools/repo/repo_for_tools.yml
+++ b/tests/conf_with_tools/repo/repo_for_tools.yml
@@ -1,6 +1,6 @@
 # For testing: this repo must NOT exist to test creation
-test-repo-for-tools:
-  name: Repository for tools
+test-repo-for-tools-1:
+  name: Repository for tools with branch = master
   description: Repo used to run real tests on oca-repo-manage tool.
   category: Accounting
   psc: test-team-2
@@ -9,6 +9,15 @@ test-repo-for-tools:
   default_branch: "master"
   branches:
     - "master"
+test-repo-for-tools-2:
+  name: Repository for tools with branch = main
+  description: Repo used to run real tests on oca-repo-manage tool.
+  category: Accounting
+  psc: test-team-2
+  maintainers:
+    - simahawk
+  default_branch: "main"
+  branches: []
 test-repo-for-tools-with-no-branches:
   name: Repository for tools
   description: Repo used to run real tests on oca-repo-manage tool.

--- a/tests/conf_with_tools/repo/repo_for_tools.yml
+++ b/tests/conf_with_tools/repo/repo_for_tools.yml
@@ -1,0 +1,20 @@
+# For testing: this repo must NOT exist to test creation
+test-repo-for-tools:
+  name: Repository for tools
+  description: Repo used to run real tests on oca-repo-manage tool.
+  category: Accounting
+  psc: test-team-2
+  maintainers:
+    - simahawk
+  default_branch: "master"
+  branches:
+    - "master"
+test-repo-for-tools-with-no-branches:
+  name: Repository for tools
+  description: Repo used to run real tests on oca-repo-manage tool.
+  category: Accounting
+  psc: test-team-2
+  maintainers:
+    - simahawk
+  default_branch: "master"
+  branches: []

--- a/tests/test_conf_file_manager.py
+++ b/tests/test_conf_file_manager.py
@@ -48,8 +48,10 @@ class TestManager(TestCase):
 
             self.assertEqual(conf["test-repo-for-addons"]["branches"], ["16.0", "15.0"])
             self.assertEqual(conf["test-repo-for-addons"]["default_branch"], "16.0")
-            self.assertEqual(conf["test-repo-for-tools"]["branches"], ["master"])
-            self.assertEqual(conf["test-repo-for-tools"]["default_branch"], "master")
+            self.assertEqual(conf["test-repo-for-tools-1"]["branches"], ["master"])
+            self.assertEqual(conf["test-repo-for-tools-1"]["default_branch"], "master")
+            self.assertEqual(conf["test-repo-for-tools-2"]["branches"], [])
+            self.assertEqual(conf["test-repo-for-tools-2"]["default_branch"], "main")
             self.assertEqual(
                 conf["test-repo-for-tools-with-no-branches"]["branches"], []
             )
@@ -65,8 +67,10 @@ class TestManager(TestCase):
                 conf["test-repo-for-addons"]["branches"], ["16.0", "15.0", "100.0"]
             )
             self.assertEqual(conf["test-repo-for-addons"]["default_branch"], "100.0")
-            self.assertEqual(conf["test-repo-for-tools"]["branches"], ["master"])
-            self.assertEqual(conf["test-repo-for-tools"]["default_branch"], "master")
+            self.assertEqual(conf["test-repo-for-tools-1"]["branches"], ["master"])
+            self.assertEqual(conf["test-repo-for-tools-1"]["default_branch"], "master")
+            self.assertEqual(conf["test-repo-for-tools-2"]["branches"], [])
+            self.assertEqual(conf["test-repo-for-tools-2"]["default_branch"], "main")
             self.assertEqual(
                 conf["test-repo-for-tools-with-no-branches"]["branches"], []
             )

--- a/tests/test_conf_file_manager.py
+++ b/tests/test_conf_file_manager.py
@@ -77,3 +77,38 @@ class TestManager(TestCase):
             self.assertEqual(
                 conf["test-repo-for-tools-with-no-branches"]["default_branch"], "master"
             )
+
+    def test_skip_manual_mgmt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            shutil.copytree(
+                conf_path_with_tools.as_posix(), temp_dir, dirs_exist_ok=True
+            )
+            manager = ConfFileManager(temp_dir)
+            conf = manager.conf_loader.load_conf("repo")
+
+            self.assertEqual(conf["test-repo-for-addons"]["branches"], ["16.0", "15.0"])
+            self.assertEqual(conf["test-repo-for-addons"]["default_branch"], "16.0")
+            self.assertEqual(
+                conf["test-repo-for-addons-manual"]["branches"], ["16.0", "15.0"]
+            )
+            self.assertEqual(
+                conf["test-repo-for-addons-manual"]["default_branch"], "16.0"
+            )
+            self.assertEqual(
+                conf["test-repo-for-addons-manual"]["manual_branch_mgmt"], True
+            )
+
+            manager.add_branch("100.0")
+
+            conf = manager.conf_loader.load_conf("repo")
+
+            self.assertEqual(
+                conf["test-repo-for-addons"]["branches"], ["16.0", "15.0", "100.0"]
+            )
+            self.assertEqual(conf["test-repo-for-addons"]["default_branch"], "100.0")
+            self.assertEqual(
+                conf["test-repo-for-addons-manual"]["branches"], ["16.0", "15.0"]
+            )
+            self.assertEqual(
+                conf["test-repo-for-addons-manual"]["default_branch"], "16.0"
+            )

--- a/tests/test_conf_file_manager.py
+++ b/tests/test_conf_file_manager.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Camptocamp SA
+# @author: Simone Orsi
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import shutil
+import tempfile
+from unittest import TestCase
+
+from oca_repo_maintainer.tools.conf_file_manager import ConfFileManager
+
+from .common import conf_path
+
+
+class TestManager(TestCase):
+    def test_add_branch(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            shutil.copytree(conf_path.as_posix(), temp_dir, dirs_exist_ok=True)
+            manager = ConfFileManager(temp_dir)
+            manager.add_branch("100.0")
+
+            conf = manager.conf_loader.load_conf("repo")
+            self.assertTrue(conf)
+            for __, repo_data in conf.items():
+                self.assertIn("100.0", repo_data["branches"])
+                if "default_branch" in repo_data:
+                    self.assertEqual(repo_data["default_branch"], "100.0")
+
+    def test_add_branch_no_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            shutil.copytree(conf_path.as_posix(), temp_dir, dirs_exist_ok=True)
+            manager = ConfFileManager(temp_dir)
+            manager.add_branch("100.0", default=False)
+
+            conf = manager.conf_loader.load_conf("repo")
+            self.assertTrue(conf)
+            for __, repo_data in conf.items():
+                self.assertIn("100.0", repo_data["branches"])
+                if "default_branch" in repo_data:
+                    self.assertNotEqual(repo_data["default_branch"], "100.0")


### PR DESCRIPTION
Addresses 2 items of the usual flow to setup new Odoo version's branches:
* add new branch to all repos
* set it as default

Result for v18 https://github.com/OCA/repo-maintainer-conf/pull/36